### PR TITLE
Changing from 'BrowserModule' to 'CommonModule'

### DIFF
--- a/src/ionic2-rating.module.ts
+++ b/src/ionic2-rating.module.ts
@@ -1,5 +1,5 @@
 import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
+import { CommonModule } from '@angular/common';
 import { IonicModule } from 'ionic-angular';
 
 import { Ionic2Rating } from './ionic2-rating';
@@ -12,7 +12,7 @@ import { Ionic2Rating } from './ionic2-rating';
     Ionic2Rating
   ],
   imports: [
-    BrowserModule,
+    CommonModule,
     IonicModule
   ],
   schemas: [


### PR DESCRIPTION
Ionic 3 requires the import of "BrowserModule" on the app's main module, and it only can be used one time.

As the "browserModule" already exists on the application, we need to remove it from 'ionic2-rating' and add "ComomModule" to be able to use Angular directives like "ngIf" and others.